### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/subhabrataghosh/7543c41c-4d9b-4cda-bb30-d4385aeb5259/c5a01105-8aac-4629-80ed-60ffea163549/_apis/work/boardbadge/d3fc0d10-27fb-47c1-870a-ea888a41efd7)](https://dev.azure.com/subhabrataghosh/7543c41c-4d9b-4cda-bb30-d4385aeb5259/_boards/board/t/c5a01105-8aac-4629-80ed-60ffea163549/Microsoft.RequirementCategory)
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#568](https://dev.azure.com/subhabrataghosh/7543c41c-4d9b-4cda-bb30-d4385aeb5259/_workitems/edit/568). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.